### PR TITLE
Configurable gas metering

### DIFF
--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -65,12 +65,19 @@ func cWasmerCompile(module **cWasmerModuleT, wasmBytes *cUchar, wasmBytesLength 
 }
 
 // TODO: is this an auto-gen file? how should I create this?
-func cWasmerCompileWithGasMetering(module **cWasmerModuleT, wasmBytes *cUchar, wasmBytesLength cUint, gasLimit uint64) cWasmerResultT {
+func cWasmerCompileWithGasMetering(
+	module **cWasmerModuleT,
+	wasmBytes *cUchar,
+	wasmBytesLength cUint,
+	gasLimit uint64,
+	opcode_costs *[OPCODE_COUNT]uint32,
+) cWasmerResultT {
 	return (cWasmerResultT)(C.wasmer_compile_with_gas_metering(
 		(**C.wasmer_module_t)(unsafe.Pointer(module)),
 		(*C.uchar)(wasmBytes),
 		(C.uint)(wasmBytesLength),
 		(C.uint64_t)(gasLimit),
+		(*C.uint32_t)(unsafe.Pointer(opcode_costs)),
 	))
 }
 
@@ -333,7 +340,7 @@ func cWasmerInstantiateWithMetering(
 	imports *cWasmerImportT,
 	importsLength cInt,
 	gasLimit uint64,
-	costs_table_name string,
+	opcode_costs *[OPCODE_COUNT]uint32,
 ) cWasmerResultT {
 	return (cWasmerResultT)(C.wasmer_instantiate_with_metering(
 		(**C.wasmer_instance_t)(unsafe.Pointer(instance)),
@@ -342,7 +349,7 @@ func cWasmerInstantiateWithMetering(
 		(*C.wasmer_import_t)(imports),
 		(C.int)(importsLength),
 		(C.uint64_t)(gasLimit),
-		(*C.char)(C.CString(costs_table_name)),
+		(*C.uint32_t)(unsafe.Pointer(opcode_costs)),
 	))
 }
 

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -5,6 +5,8 @@ import (
 	"unsafe"
 )
 
+const OPCODE_COUNT = 410
+
 // InstanceError represents any kind of errors related to a WebAssembly instance. It
 // is returned by `Instance` functions only.
 type InstanceError struct {
@@ -112,7 +114,7 @@ func NewInstanceWithImports(bytes []byte, imports *Imports) (Instance, error) {
 }
 
 // NewInstanceWithImports constructs a new `Instance` with imported functions.
-func NewMeteredInstanceWithImports(bytes []byte, imports *Imports, gasLimit uint64, costs_table_name string) (Instance, error) {
+func NewMeteredInstanceWithImports(bytes []byte, imports *Imports, gasLimit uint64, opcode_costs *[OPCODE_COUNT]uint32) (Instance, error) {
 	return newInstanceWithImports(
 		imports,
 		func(wasmImportsCPointer *cWasmerImportT, numberOfImports int) (*cWasmerInstanceT, error) {
@@ -125,7 +127,7 @@ func NewMeteredInstanceWithImports(bytes []byte, imports *Imports, gasLimit uint
 				wasmImportsCPointer,
 				cInt(numberOfImports),
 				gasLimit,
-				costs_table_name,
+				opcode_costs,
 			)
 
 			if compileResult != cWasmerOk {

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -107,7 +107,7 @@ func Compile(bytes []byte) (Module, error) {
 }
 
 // Compile compiles a WebAssembly module from bytes, with a fixed gas limit
-func CompileWithGasMetering(bytes []byte, gasLimit uint64) (Module, error) {
+func CompileWithGasMetering(bytes []byte, gasLimit uint64, opcode_costs *[OPCODE_COUNT]uint32) (Module, error) {
 	var module *cWasmerModuleT
 
 	var compileResult = cWasmerCompileWithGasMetering(
@@ -115,6 +115,7 @@ func CompileWithGasMetering(bytes []byte, gasLimit uint64) (Module, error) {
 		(*cUchar)(unsafe.Pointer(&bytes[0])),
 		cUint(len(bytes)),
 		gasLimit,
+		opcode_costs,
 	)
 
 	var emptyModule = Module{module: nil}

--- a/wasmer/wasmer.h
+++ b/wasmer/wasmer.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define OPCODE_COUNT 410
+
 /**
  * List of export/import kinds.
  */
@@ -184,14 +186,17 @@ wasmer_result_t wasmer_compile(wasmer_module_t **module,
 
 /**
  * Creates a new Module with gas limit from the given wasm bytes.
+ *
  * Returns `wasmer_result_t::WASMER_OK` upon success.
+ *
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
 wasmer_result_t wasmer_compile_with_gas_metering(wasmer_module_t **module,
-                                          uint8_t *wasm_bytes,
-                                          uint32_t wasm_bytes_len,
-                                          uint64_t gas_limit);
+                                                 uint8_t *wasm_bytes,
+                                                 uint32_t wasm_bytes_len,
+                                                 uint64_t gas_limit,
+                                                 const uint32_t *opcode_costs_pointer);
 
 /**
  * Gets export descriptor kind
@@ -541,12 +546,12 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
                                    int imports_len);
 
 wasmer_result_t wasmer_instantiate_with_metering(wasmer_instance_t **instance,
-                                   uint8_t *wasm_bytes,
-                                   uint32_t wasm_bytes_len,
-                                   wasmer_import_t *imports,
-                                   int imports_len,
-																	 uint64_t gas_limit,
-																	 char *costs_table_name);
+                                                 uint8_t *wasm_bytes,
+                                                 uint32_t wasm_bytes_len,
+                                                 wasmer_import_t *imports,
+                                                 int imports_len,
+                                                 uint64_t gas_limit,
+                                                 const uint32_t *opcode_costs_pointer);
 
 /**
  * Gets the length in bytes of the last error.
@@ -641,8 +646,9 @@ void wasmer_module_destroy(wasmer_module_t *module);
 
 /**
  * Given:
- *  A prepared `wasmer` import-object
- *  A compiled wasmer module
+ * * A prepared `wasmer` import-object
+ * * A compiled wasmer module
+ *
  * Instantiates a wasmer instance
  */
 wasmer_result_t wasmer_module_import_instantiate(wasmer_instance_t **instance,


### PR DESCRIPTION
`go-ext-wasm` now accepts an `opcode_costs` array when creating a metered Wasmer instance.